### PR TITLE
build: remove six and add needed requirements for centos10

### DIFF
--- a/ovirt-lldp-labeler.spec.in
+++ b/ovirt-lldp-labeler.spec.in
@@ -29,10 +29,10 @@ URL:            https://gerrit.ovirt.org/#/admin/projects/ovirt-lldp-labeler
 Source0:        %{name}-%{version}.tar.gz
 
 Requires: %{required_python}-ovirt-engine-sdk4 >= 4.2.0
-Requires: %{required_python}-six
 
 BuildRequires: %{required_python}
 BuildRequires: systemd
+BuildRequires: make
 
 %prep
 %autosetup

--- a/src/labeler/config.py.in
+++ b/src/labeler/config.py.in
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import six.moves.configparser
+import configparser
 
 _LABELER_CONFIG_FILE = '@LABELER_CONFIG@'
 _CREDENTIALS_CONFIG_FILE = '@LABELER_CONFIG_CREDENTIALS@'
@@ -33,7 +33,7 @@ _COMMA_SEPARATOR = ','
 
 _CONFIG_TRUE = 'true'
 
-_config = six.moves.configparser.ConfigParser()
+_config = configparser.ConfigParser()
 _config.read(_LABELER_CONFIG_FILE)
 _config.read(_CREDENTIALS_CONFIG_FILE)
 


### PR DESCRIPTION
* Remove usage of outdated python-six
* Add Buildrequirement for make dependency that is not standard included for centos10